### PR TITLE
A few tweaks that should be applied when you update the GA version 2.8.0.5813

### DIFF
--- a/CustomScripts/nVIDIAdTeradiciLeostreamAgents.ps1
+++ b/CustomScripts/nVIDIAdTeradiciLeostreamAgents.ps1
@@ -141,75 +141,44 @@ if ($license) {
 	Write-Host "pre-activate"
 	.\appactutil.exe -served -comm soap -commServer https://teradici.flexnetoperations.com/control/trdi/ActivationService -entitlementID $license
 	Write-Host "activation over"
-	if ((($teradiciAgentVer -match "2.7.0.4060") -or ($teradiciAgentVer -like '*2.8*')) -and ($nvidiaVer -match "369.71"))
+	if ($nvidiaVer -match "369.71")
 	{
-	#if (($teradiciAgentVer -match "2.7.0.4060") -or ($teradiciAgentVer -like '*2.8*'))
-		if ($teradiciAgentVer -match "2.7.0.4060")
-		{
-		  IF(!(Test-Path $registryPath))
-			  {
-			  New-Item -Path $registryPath -Force | Out-Null
-			  New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
-			  }
-		  ELSE 
-			  {
-			  New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
-			  }
-		 }
-		 else
-		 { 
-			Write-Host  "Agent 2.8 - No Registry entry required"
-		 }
+		<# NVIDIA driver kicking Only needed for 369.71 driver #>
 
-			<# NVIDIA driver kicking Only needed for 369.71 driver #>
-			#if ($nvidiaVer -match "369.71")
-
-			Write-Host "Driver kick needed for this NVIDIA graphics driver 369.71, kicking now..."
-			Set-Location "C:\Program Files (x86)\Teradici\PCoIP Agent\GRID"
+		Write-Host "Driver kick needed for this NVIDIA graphics driver 369.71, kicking now..."
+		Set-Location "C:\Program Files (x86)\Teradici\PCoIP Agent\GRID"
     
-			Write-Host "Stopping NVIDIA Display Driver"
-			net stop nvsvc
-			Start-Sleep -s 90#>
+		Write-Host "Stopping NVIDIA Display Driver"
+		net stop nvsvc
+		Start-Sleep -s 90#>
     
-			Write-Host "Disabling NVFBC capture"
-			./NvFBCEnable -disable
-			Start-Sleep -s 90
+		Write-Host "Disabling NVFBC capture"
+		./NvFBCEnable -disable
+		Start-Sleep -s 90
     
-			Write-Host "Enabling NVFBC capture"
-			./NvFBCEnable -enable
-			Start-Sleep -s 90
+		Write-Host "Enabling NVFBC capture"
+		./NvFBCEnable -enable
+		Start-Sleep -s 90
     
-			Write-Host "Starting NVIDIA Display Driver"
-			net start nvsvc
-			Start-Sleep -s 90
+		Write-Host "Starting NVIDIA Display Driver"
+		net start nvsvc
+		Start-Sleep -s 90
 	}
-	else
-	{ 
-		Write-Host  "Not 369.71."
+	if ($teradiciAgentVer -like "*2.7*")
+	{
 		
-			<# NVIDIA driver kicking ALSO needed for 369.95 driver #>
-			#if ($nvidiaVer -match "369.95")
+		<# Enable multi-threaded encoding for 2.7 PCoIP Agents #>
 
-			Write-Host "Driver kick ALSO needed for this NVIDIA graphics driver 369.95, kicking now..."
-			Set-Location "C:\Program Files (x86)\Teradici\PCoIP Agent\GRID"
-    
-			<#Write-Host "Stopping NVIDIA Display Driver"
-			net stop nvsvc
-			Start-Sleep -s 90#>
-    
-			Write-Host "Disabling NVFBC capture"
-			./NvFBCEnable -disable
-			Start-Sleep -s 480
-    
-			Write-Host "Enabling NVFBC capture"
-			./NvFBCEnable -enable
-			Start-Sleep -s 90
-    
-			<#Write-Host "Starting NVIDIA Display Driver"
-			net start nvsvc
-			Start-Sleep -s 480#>
+        IF(!(Test-Path $registryPath))
+		{
+			New-Item -Path $registryPath -Force | Out-Null
+			New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+		}
+		ELSE 
+		{
+			New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+		}
 	}
-
 }
 
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ Tip: Map you local drive only when using Remote Desktop Client (not PCoIP) to tr
 * nView needs to be enabled manually. [User Guide](http://www.nvidia.com/content/quadro/pdf/nView-user-guide.pdf)
 * Collection of the user dumps for the NVIDIA Display Driver 369.95 or 369.71  from within the VM on Display Driver Crash if occurs.
  * Details are [here](http://nvidia.custhelp.com/app/answers/detail/a_id/3335/~/tdr-(timeout-detection-and-recovery)-and-collecting-dump-files) 
-* PCoIP Graphics Agent for Windows Log Collection (2.8.0.5614 (2.8 Beta Presently) and 2.7.0.4060) from the Teradici System Tray (right click Teradici Icon on System Tray) and collect Agent Logs (from the pop-up).
- * PCoIP Graphics Agent for Windows 2.8.0.5614 (2.8 Beta Presently) and 2.7.0.4060  uses Multiple PCoIP encoding.
-* The PCOIP Agent Logs  [v1.11 ~Beta]((https://techsupport.teradici.com/link/portal/15134/15164/Download/2852)) from the Office Client machine of the end-user from <code>C:\Users\user_name\AppData\Local\Teradici\PCoIPClient\logs</code>
+* PCoIP Graphics Agent for Windows Log Collection from the Teradici System Tray (right click Teradici Icon on System Tray) and collect Agent Logs (from the support tab).
+* The PCoIP Client Logs  [v1.11 ~Beta]((https://techsupport.teradici.com/link/portal/15134/15164/Download/2852)) from the Office Client machine of the end-user from <code>C:\Users\user_name\AppData\Local\Teradici\PCoIPClient\logs</code>
 
 #### Optional Usage of Operational Management Suite
 **OMS Setup (for mostly Security, compliance and backup in this case) is optional and the OMS Workspace Id and OMS Workspace Key can either be kept blank or populated post the steps below.**


### PR DESCRIPTION
Hi Dwai,

A few recommended tweaks to your scripts that should be applied when you update the GA version 2.8.0.5813.

Summary of changes:
* Clarified a few bits in the readme 
* Separated NVIDA driver version logic from PCoIP Graphics Agent version logic and simplified things a little
* Removed the driver kicking for NVIDIA drivers post 369.71. There was an installer issue with GA 2.8.0.5614 (fixed in GA version 2.8.0.5813) that was forcing you to still require the kick with the new driver. Also note, there is an open NVIDIA bug with the 369.95 that will disable GRID licensing when calling NvFBCEnable -disable as such if the you do kick the driver, you need to call same kick steps as used for the 369.71 driver.

We can discuss these changes further during our call on Wednesday March 15th if need be.

Best Regards,

Garry
